### PR TITLE
Support Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
   "require": {
     "php": "^8.0",
     "ext-dom": "*",
-    "illuminate/collections": "^7.0|^8.0|^9.0"
+    "illuminate/collections": "^7.0|^8.0|^9.0|^10.0"
   }
 }


### PR DESCRIPTION
This PR adds support for **Laravel 10**.

On a **Laravel 10** project, with the current `dev-main` branch, you get the following error when trying to install the package.

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - illuminate/collections[v8.0.0, ..., v8.11.2] require php ^7.3 -> your php version (8.2.1) does not satisfy that requirement.
    - Root composer.json requires stechstudio/phpinfo dev-main -> satisfiable by stechstudio/phpinfo[dev-main].
    - Conclusion: don't install laravel/framework v10.1.2 (conflict analysis result)
    - Conclusion: don't install laravel/framework v10.1.3 (conflict analysis result)
    - Conclusion: don't install laravel/framework v10.1.4 (conflict analysis result)
    - Conclusion: don't install laravel/framework v10.1.5 (conflict analysis result)
    - Conclusion: don't install laravel/framework v10.1.1 (conflict analysis result)
    - stechstudio/phpinfo dev-main requires illuminate/collections ^7.0|^8.0|^9.0 -> satisfiable by illuminate/collections[v8.0.0, ..., v8.83.27, v9.0.0, ..., v9.52.4].
    - Only one of these can be installed: illuminate/collections[v8.0.0, ..., v8.83.27, v9.0.0, ..., v9.52.4, v10.0.0, ..., v10.1.5], laravel/framework[v10.1.0, ..., v10.1.5]. laravel/framework replaces illuminate/collections and thus cannot coexist with it.
    - Root composer.json requires laravel/framework ^10.1 -> satisfiable by laravel/framework[v10.1.0, ..., v10.1.5].
```